### PR TITLE
List grouping

### DIFF
--- a/Grocery Geek.xcodeproj/project.pbxproj
+++ b/Grocery Geek.xcodeproj/project.pbxproj
@@ -11,10 +11,14 @@
 		B422F174251C367F0027862A /* GroceryListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B422F173251C367F0027862A /* GroceryListManager.swift */; };
 		B4244BF1251266C700FAEA14 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4244BF0251266C700FAEA14 /* HomeViewController.swift */; };
 		B4244BF32512978F00FAEA14 /* ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4244BF22512978F00FAEA14 /* ListItem.swift */; };
-		B4395DEF251C3C6600A23721 /* List+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4395DE9251C3C6600A23721 /* List+CoreDataClass.swift */; };
-		B4395DF0251C3C6600A23721 /* List+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4395DEA251C3C6600A23721 /* List+CoreDataProperties.swift */; };
-		B4395DF1251C3C6600A23721 /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4395DEB251C3C6600A23721 /* Product+CoreDataClass.swift */; };
-		B4395DF2251C3C6600A23721 /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4395DEC251C3C6600A23721 /* Product+CoreDataProperties.swift */; };
+		B4260314252299F300F56061 /* Section+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B426030C252299F300F56061 /* Section+CoreDataClass.swift */; };
+		B4260315252299F300F56061 /* Section+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B426030D252299F300F56061 /* Section+CoreDataProperties.swift */; };
+		B4260316252299F300F56061 /* Barcode+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B426030E252299F300F56061 /* Barcode+CoreDataClass.swift */; };
+		B4260317252299F300F56061 /* Barcode+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B426030F252299F300F56061 /* Barcode+CoreDataProperties.swift */; };
+		B4260318252299F300F56061 /* List+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4260310252299F300F56061 /* List+CoreDataClass.swift */; };
+		B4260319252299F300F56061 /* List+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4260311252299F300F56061 /* List+CoreDataProperties.swift */; };
+		B426031A252299F300F56061 /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4260312252299F300F56061 /* Product+CoreDataClass.swift */; };
+		B426031B252299F300F56061 /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4260313252299F300F56061 /* Product+CoreDataProperties.swift */; };
 		B45A50962282006E0004BB54 /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45A50952282006E0004BB54 /* ScanViewController.swift */; };
 		B46173AC2454E498004DD830 /* AddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46173AB2454E498004DD830 /* AddViewController.swift */; };
 		B469F8ED251EA9000042247D /* ListTableManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B469F8EC251EA9000042247D /* ListTableManagerTests.swift */; };
@@ -23,8 +27,6 @@
 		B46E535A251FD82F00D4E145 /* BarcodeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E5359251FD82F00D4E145 /* BarcodeManagerTests.swift */; };
 		B4872D8E22948CF0008D0F20 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B4872D8C22948CF0008D0F20 /* Model.xcdatamodeld */; };
 		B4B76D6E251D6380004BC32F /* BarcodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B76D6D251D6380004BC32F /* BarcodeManager.swift */; };
-		B4B76D73251D66F5004BC32F /* Barcode+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B76D71251D66F5004BC32F /* Barcode+CoreDataClass.swift */; };
-		B4B76D74251D66F5004BC32F /* Barcode+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B76D72251D66F5004BC32F /* Barcode+CoreDataProperties.swift */; };
 		B4B947E22511A76F00C7FDFF /* GroceryListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B947E12511A76F00C7FDFF /* GroceryListTableView.swift */; };
 		B4C556972280BAAD00989D46 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C556962280BAAD00989D46 /* AppDelegate.swift */; };
 		B4C556992280BAAD00989D46 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C556982280BAAD00989D46 /* ListViewController.swift */; };
@@ -49,10 +51,14 @@
 		B422F173251C367F0027862A /* GroceryListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroceryListManager.swift; sourceTree = "<group>"; };
 		B4244BF0251266C700FAEA14 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		B4244BF22512978F00FAEA14 /* ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItem.swift; sourceTree = "<group>"; };
-		B4395DE9251C3C6600A23721 /* List+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+CoreDataClass.swift"; sourceTree = "<group>"; };
-		B4395DEA251C3C6600A23721 /* List+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		B4395DEB251C3C6600A23721 /* Product+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataClass.swift"; sourceTree = "<group>"; };
-		B4395DEC251C3C6600A23721 /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B426030C252299F300F56061 /* Section+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Section+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B426030D252299F300F56061 /* Section+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Section+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B426030E252299F300F56061 /* Barcode+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Barcode+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B426030F252299F300F56061 /* Barcode+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Barcode+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B4260310252299F300F56061 /* List+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B4260311252299F300F56061 /* List+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B4260312252299F300F56061 /* Product+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B4260313252299F300F56061 /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B45A50952282006E0004BB54 /* ScanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanViewController.swift; sourceTree = "<group>"; };
 		B46173AB2454E498004DD830 /* AddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
 		B469F8EA251EA9000042247D /* Grocery GeekTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Grocery GeekTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -63,8 +69,6 @@
 		B46E5359251FD82F00D4E145 /* BarcodeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeManagerTests.swift; sourceTree = "<group>"; };
 		B4872D8D22948CF0008D0F20 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		B4B76D6D251D6380004BC32F /* BarcodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeManager.swift; sourceTree = "<group>"; };
-		B4B76D71251D66F5004BC32F /* Barcode+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Barcode+CoreDataClass.swift"; sourceTree = "<group>"; };
-		B4B76D72251D66F5004BC32F /* Barcode+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Barcode+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B4B947E12511A76F00C7FDFF /* GroceryListTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroceryListTableView.swift; sourceTree = "<group>"; };
 		B4C556932280BAAD00989D46 /* Grocery Geek.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Grocery Geek.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4C556962280BAAD00989D46 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -97,12 +101,14 @@
 		B41C8BDD2510292F00EAD7FE /* Core Data */ = {
 			isa = PBXGroup;
 			children = (
-				B4B76D71251D66F5004BC32F /* Barcode+CoreDataClass.swift */,
-				B4B76D72251D66F5004BC32F /* Barcode+CoreDataProperties.swift */,
-				B4395DE9251C3C6600A23721 /* List+CoreDataClass.swift */,
-				B4395DEA251C3C6600A23721 /* List+CoreDataProperties.swift */,
-				B4395DEB251C3C6600A23721 /* Product+CoreDataClass.swift */,
-				B4395DEC251C3C6600A23721 /* Product+CoreDataProperties.swift */,
+				B426030C252299F300F56061 /* Section+CoreDataClass.swift */,
+				B426030D252299F300F56061 /* Section+CoreDataProperties.swift */,
+				B426030E252299F300F56061 /* Barcode+CoreDataClass.swift */,
+				B426030F252299F300F56061 /* Barcode+CoreDataProperties.swift */,
+				B4260310252299F300F56061 /* List+CoreDataClass.swift */,
+				B4260311252299F300F56061 /* List+CoreDataProperties.swift */,
+				B4260312252299F300F56061 /* Product+CoreDataClass.swift */,
+				B4260313252299F300F56061 /* Product+CoreDataProperties.swift */,
 				B4872D8C22948CF0008D0F20 /* Model.xcdatamodeld */,
 			);
 			path = "Core Data";
@@ -291,21 +297,23 @@
 			files = (
 				B4244BF32512978F00FAEA14 /* ListItem.swift in Sources */,
 				B46173AC2454E498004DD830 /* AddViewController.swift in Sources */,
-				B4395DEF251C3C6600A23721 /* List+CoreDataClass.swift in Sources */,
+				B4260315252299F300F56061 /* Section+CoreDataProperties.swift in Sources */,
+				B4260316252299F300F56061 /* Barcode+CoreDataClass.swift in Sources */,
+				B4260318252299F300F56061 /* List+CoreDataClass.swift in Sources */,
+				B4260314252299F300F56061 /* Section+CoreDataClass.swift in Sources */,
 				B4C556992280BAAD00989D46 /* ListViewController.swift in Sources */,
 				B4C556972280BAAD00989D46 /* AppDelegate.swift in Sources */,
-				B4395DF0251C3C6600A23721 /* List+CoreDataProperties.swift in Sources */,
 				B4B947E22511A76F00C7FDFF /* GroceryListTableView.swift in Sources */,
 				B422F174251C367F0027862A /* GroceryListManager.swift in Sources */,
-				B4395DF1251C3C6600A23721 /* Product+CoreDataClass.swift in Sources */,
+				B426031B252299F300F56061 /* Product+CoreDataProperties.swift in Sources */,
 				B4244BF1251266C700FAEA14 /* HomeViewController.swift in Sources */,
+				B426031A252299F300F56061 /* Product+CoreDataClass.swift in Sources */,
 				B4081D0C251D7D0C00D8CAC1 /* ListTableManager.swift in Sources */,
-				B4B76D73251D66F5004BC32F /* Barcode+CoreDataClass.swift in Sources */,
-				B4B76D74251D66F5004BC32F /* Barcode+CoreDataProperties.swift in Sources */,
 				B4B76D6E251D6380004BC32F /* BarcodeManager.swift in Sources */,
+				B4260319252299F300F56061 /* List+CoreDataProperties.swift in Sources */,
+				B4260317252299F300F56061 /* Barcode+CoreDataProperties.swift in Sources */,
 				B4872D8E22948CF0008D0F20 /* Model.xcdatamodeld in Sources */,
 				B45A50962282006E0004BB54 /* ScanViewController.swift in Sources */,
-				B4395DF2251C3C6600A23721 /* Product+CoreDataProperties.swift in Sources */,
 				B4F8F555228A0F0500575AFA /* GroceryItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Grocery Geek/AppDelegate.swift
+++ b/Grocery Geek/AppDelegate.swift
@@ -65,6 +65,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
     }
-    
+
 }
 

--- a/Grocery Geek/Base.lproj/Main.storyboard
+++ b/Grocery Geek/Base.lproj/Main.storyboard
@@ -43,7 +43,6 @@
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bZ0-hd-ty4">
                                                             <rect key="frame" x="332" y="2" width="13" height="40.5"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="23.5" id="5PB-WM-Lnf"/>
                                                                 <constraint firstAttribute="width" constant="13" id="jSP-dY-uAc"/>
                                                             </constraints>
                                                         </imageView>
@@ -124,53 +123,18 @@
                                         </connections>
                                     </barButtonItem>
                                     <barButtonItem systemItem="flexibleSpace" id="nbs-RV-Nhi"/>
-                                    <barButtonItem title="Scan" image="barcode.viewfinder" catalog="system" id="o9e-np-tDf" userLabel="Scan">
+                                    <barButtonItem title="AddGroup" image="plus.rectangle" catalog="system" id="spI-gK-Elf">
                                         <connections>
-                                            <segue destination="gzv-8T-iTN" kind="presentation" identifier="scanProduct" modalPresentationStyle="fullScreen" modalTransitionStyle="coverVertical" id="dII-b9-nph"/>
+                                            <action selector="addSection:" destination="xO8-gZ-rOd" id="Hhh-1J-OrU"/>
                                         </connections>
                                     </barButtonItem>
-                                    <barButtonItem systemItem="flexibleSpace" id="TrI-lo-apc"/>
-                                    <barButtonItem title="Add" image="plus" catalog="system" id="BA2-O6-ZMN">
-                                        <inset key="imageInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        <connections>
-                                            <segue destination="YOP-Za-fsU" kind="presentation" identifier="addProduct" modalPresentationStyle="fullScreen" id="943-JN-0lX"/>
-                                        </connections>
-                                    </barButtonItem>
-                                    <barButtonItem systemItem="flexibleSpace" id="LuU-ad-gpv"/>
-                                    <barButtonItem title="Undo" image="arrow.uturn.left" catalog="system" id="kdE-oW-Tg0">
-                                        <connections>
-                                            <action selector="undoRemove:" destination="xO8-gZ-rOd" id="wfB-qC-rQq"/>
-                                        </connections>
-                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="CId-2o-uWs"/>
+                                    <barButtonItem title="Share" image="square.and.arrow.up" catalog="system" id="r02-OR-cy4"/>
                                 </items>
                             </toolbar>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="elq-9H-mgT">
-                                <rect key="frame" x="0.0" y="44" width="375" height="40"/>
-                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cYY-f6-HdT">
-                                <rect key="frame" x="15" y="44" width="345" height="40"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Item" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h26-bQ-u2V">
-                                        <rect key="frame" x="0.0" y="0.0" width="263.5" height="40"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Quantity" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nt4-vw-fya">
-                                        <rect key="frame" x="263.5" y="0.0" width="81.5" height="40"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="JFB-8g-yjg"/>
-                                </constraints>
-                            </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="bQo-7k-Mni" userLabel="Grocery List">
-                                <rect key="frame" x="0.0" y="84" width="375" height="533"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="573"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="separatorColor" systemColor="systemGrayColor"/>
                                 <prototypes>
                                     <tableViewCell autoresizesSubviews="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="5" reuseIdentifier="ProductItem" id="9Av-fo-NJH" userLabel="ProductItem" customClass="GroceryItem" customModule="Grocery_Geek" customModuleProvider="target">
@@ -219,23 +183,16 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="78P-Gu-WAG" firstAttribute="bottom" secondItem="Auc-X9-k46" secondAttribute="bottom" id="9iJ-dV-3xL"/>
-                            <constraint firstAttribute="trailing" secondItem="elq-9H-mgT" secondAttribute="trailing" id="BlZ-CC-Lnc"/>
-                            <constraint firstItem="bQo-7k-Mni" firstAttribute="top" secondItem="elq-9H-mgT" secondAttribute="bottom" id="GHt-pV-cPg"/>
                             <constraint firstItem="Auc-X9-k46" firstAttribute="leading" secondItem="78P-Gu-WAG" secondAttribute="leading" id="JZu-WK-6Ze"/>
-                            <constraint firstItem="78P-Gu-WAG" firstAttribute="trailing" secondItem="cYY-f6-HdT" secondAttribute="trailing" constant="15" id="JmD-dE-Hjf"/>
-                            <constraint firstItem="cYY-f6-HdT" firstAttribute="top" secondItem="78P-Gu-WAG" secondAttribute="top" id="Nh6-51-kjG"/>
                             <constraint firstItem="coE-6S-Iv2" firstAttribute="top" secondItem="78P-Gu-WAG" secondAttribute="top" id="Pgy-ry-yP0"/>
                             <constraint firstItem="coE-6S-Iv2" firstAttribute="bottom" secondItem="2iF-RT-cUG" secondAttribute="bottom" id="QKj-Vo-D2G"/>
+                            <constraint firstItem="bQo-7k-Mni" firstAttribute="top" secondItem="78P-Gu-WAG" secondAttribute="top" id="QQh-ON-TuN"/>
                             <constraint firstItem="Auc-X9-k46" firstAttribute="trailing" secondItem="78P-Gu-WAG" secondAttribute="trailing" id="R6X-Sg-4bv"/>
                             <constraint firstItem="bQo-7k-Mni" firstAttribute="leading" secondItem="78P-Gu-WAG" secondAttribute="leading" id="csa-yg-ra4"/>
-                            <constraint firstItem="elq-9H-mgT" firstAttribute="top" secondItem="78P-Gu-WAG" secondAttribute="top" id="dhc-od-9f0"/>
-                            <constraint firstItem="elq-9H-mgT" firstAttribute="leading" secondItem="2iF-RT-cUG" secondAttribute="leading" id="fbY-3b-pmp"/>
                             <constraint firstItem="Auc-X9-k46" firstAttribute="top" secondItem="bQo-7k-Mni" secondAttribute="bottom" id="i42-5d-ae4"/>
-                            <constraint firstItem="bQo-7k-Mni" firstAttribute="top" secondItem="cYY-f6-HdT" secondAttribute="bottom" id="ojs-CC-DEj"/>
                             <constraint firstItem="78P-Gu-WAG" firstAttribute="trailing" secondItem="bQo-7k-Mni" secondAttribute="trailing" id="ool-GU-MkM"/>
                             <constraint firstItem="coE-6S-Iv2" firstAttribute="trailing" secondItem="2iF-RT-cUG" secondAttribute="trailing" id="q5t-oG-KgX"/>
                             <constraint firstItem="coE-6S-Iv2" firstAttribute="leading" secondItem="2iF-RT-cUG" secondAttribute="leading" id="wsH-vR-a8q"/>
-                            <constraint firstItem="cYY-f6-HdT" firstAttribute="leading" secondItem="78P-Gu-WAG" secondAttribute="leading" constant="15" id="xP0-IG-oul"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="My Grocery List" id="svI-t5-1HL">
@@ -249,11 +206,13 @@
                         <outlet property="editButton" destination="WG6-0x-VhF" id="D8X-E5-Fes"/>
                         <outlet property="groceryList" destination="bQo-7k-Mni" id="8mx-E0-fNG"/>
                         <outlet property="navigationBar" destination="svI-t5-1HL" id="Zep-zz-B2s"/>
+                        <segue destination="YOP-Za-fsU" kind="presentation" identifier="addProduct" modalPresentationStyle="fullScreen" id="Qvf-nY-6t1"/>
+                        <segue destination="gzv-8T-iTN" kind="presentation" identifier="scanProduct" modalPresentationStyle="fullScreen" id="men-Tp-rdM"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xMp-Gd-7LX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1608.8" y="903.59820089955031"/>
+            <point key="canvasLocation" x="1614" y="904"/>
         </scene>
         <!--Add View Controller-->
         <scene sceneID="Kg5-N3-qlC">
@@ -426,15 +385,15 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="943-JN-0lX"/>
+        <segue reference="Qvf-nY-6t1"/>
     </inferredMetricsTieBreakers>
     <resources>
-        <image name="arrow.uturn.left" catalog="system" width="128" height="112"/>
         <image name="background" width="2000" height="2000"/>
-        <image name="barcode.viewfinder" catalog="system" width="128" height="115"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="clear" catalog="system" width="128" height="114"/>
         <image name="plus" catalog="system" width="128" height="113"/>
+        <image name="plus.rectangle" catalog="system" width="128" height="93"/>
+        <image name="square.and.arrow.up" catalog="system" width="115" height="128"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/Grocery Geek/Core Data/Barcode+CoreDataProperties.swift
+++ b/Grocery Geek/Core Data/Barcode+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Barcode+CoreDataProperties.swift
 //  Grocery Geek
 //
-//  Created by Micah Beech on 2020-09-24.
+//  Created by Micah Beech on 2020-09-28.
 //  Copyright © 2020 Micah Beech. All rights reserved.
 //
 //

--- a/Grocery Geek/Core Data/List+CoreDataClass.swift
+++ b/Grocery Geek/Core Data/List+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  List+CoreDataClass.swift
 //  Grocery Geek
 //
-//  Created by Micah Beech on 2020-09-23.
+//  Created by Micah Beech on 2020-09-28.
 //  Copyright © 2020 Micah Beech. All rights reserved.
 //
 //

--- a/Grocery Geek/Core Data/List+CoreDataProperties.swift
+++ b/Grocery Geek/Core Data/List+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  List+CoreDataProperties.swift
 //  Grocery Geek
 //
-//  Created by Micah Beech on 2020-09-23.
+//  Created by Micah Beech on 2020-09-28.
 //  Copyright © 2020 Micah Beech. All rights reserved.
 //
 //
@@ -17,81 +17,44 @@ extension List {
         return NSFetchRequest<List>(entityName: "List")
     }
 
-    @NSManaged public var id: UUID?
     @NSManaged public var index: Int32
     @NSManaged public var name: String?
-    @NSManaged public var currentProducts: NSOrderedSet?
-    @NSManaged public var removedProducts: NSOrderedSet?
+    @NSManaged public var sections: NSOrderedSet?
 
 }
 
-// MARK: Generated accessors for currentProducts
+// MARK: Generated accessors for sections
 extension List {
 
-    @objc(insertObject:inCurrentProductsAtIndex:)
-    @NSManaged public func insertIntoCurrentProducts(_ value: Product, at idx: Int)
+    @objc(insertObject:inSectionsAtIndex:)
+    @NSManaged public func insertIntoSections(_ value: Section, at idx: Int)
 
-    @objc(removeObjectFromCurrentProductsAtIndex:)
-    @NSManaged public func removeFromCurrentProducts(at idx: Int)
+    @objc(removeObjectFromSectionsAtIndex:)
+    @NSManaged public func removeFromSections(at idx: Int)
 
-    @objc(insertCurrentProducts:atIndexes:)
-    @NSManaged public func insertIntoCurrentProducts(_ values: [Product], at indexes: NSIndexSet)
+    @objc(insertSections:atIndexes:)
+    @NSManaged public func insertIntoSections(_ values: [Section], at indexes: NSIndexSet)
 
-    @objc(removeCurrentProductsAtIndexes:)
-    @NSManaged public func removeFromCurrentProducts(at indexes: NSIndexSet)
+    @objc(removeSectionsAtIndexes:)
+    @NSManaged public func removeFromSections(at indexes: NSIndexSet)
 
-    @objc(replaceObjectInCurrentProductsAtIndex:withObject:)
-    @NSManaged public func replaceCurrentProducts(at idx: Int, with value: Product)
+    @objc(replaceObjectInSectionsAtIndex:withObject:)
+    @NSManaged public func replaceSections(at idx: Int, with value: Section)
 
-    @objc(replaceCurrentProductsAtIndexes:withCurrentProducts:)
-    @NSManaged public func replaceCurrentProducts(at indexes: NSIndexSet, with values: [Product])
+    @objc(replaceSectionsAtIndexes:withSections:)
+    @NSManaged public func replaceSections(at indexes: NSIndexSet, with values: [Section])
 
-    @objc(addCurrentProductsObject:)
-    @NSManaged public func addToCurrentProducts(_ value: Product)
+    @objc(addSectionsObject:)
+    @NSManaged public func addToSections(_ value: Section)
 
-    @objc(removeCurrentProductsObject:)
-    @NSManaged public func removeFromCurrentProducts(_ value: Product)
+    @objc(removeSectionsObject:)
+    @NSManaged public func removeFromSections(_ value: Section)
 
-    @objc(addCurrentProducts:)
-    @NSManaged public func addToCurrentProducts(_ values: NSOrderedSet)
+    @objc(addSections:)
+    @NSManaged public func addToSections(_ values: NSOrderedSet)
 
-    @objc(removeCurrentProducts:)
-    @NSManaged public func removeFromCurrentProducts(_ values: NSOrderedSet)
-
-}
-
-// MARK: Generated accessors for removedProducts
-extension List {
-
-    @objc(insertObject:inRemovedProductsAtIndex:)
-    @NSManaged public func insertIntoRemovedProducts(_ value: Product, at idx: Int)
-
-    @objc(removeObjectFromRemovedProductsAtIndex:)
-    @NSManaged public func removeFromRemovedProducts(at idx: Int)
-
-    @objc(insertRemovedProducts:atIndexes:)
-    @NSManaged public func insertIntoRemovedProducts(_ values: [Product], at indexes: NSIndexSet)
-
-    @objc(removeRemovedProductsAtIndexes:)
-    @NSManaged public func removeFromRemovedProducts(at indexes: NSIndexSet)
-
-    @objc(replaceObjectInRemovedProductsAtIndex:withObject:)
-    @NSManaged public func replaceRemovedProducts(at idx: Int, with value: Product)
-
-    @objc(replaceRemovedProductsAtIndexes:withRemovedProducts:)
-    @NSManaged public func replaceRemovedProducts(at indexes: NSIndexSet, with values: [Product])
-
-    @objc(addRemovedProductsObject:)
-    @NSManaged public func addToRemovedProducts(_ value: Product)
-
-    @objc(removeRemovedProductsObject:)
-    @NSManaged public func removeFromRemovedProducts(_ value: Product)
-
-    @objc(addRemovedProducts:)
-    @NSManaged public func addToRemovedProducts(_ values: NSOrderedSet)
-
-    @objc(removeRemovedProducts:)
-    @NSManaged public func removeFromRemovedProducts(_ values: NSOrderedSet)
+    @objc(removeSections:)
+    @NSManaged public func removeFromSections(_ values: NSOrderedSet)
 
 }
 

--- a/Grocery Geek/Core Data/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Grocery Geek/Core Data/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -7,23 +7,28 @@
         <relationship name="product" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="barcode" inverseEntity="Product"/>
     </entity>
     <entity name="List" representedClassName=".List" syncable="YES">
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <relationship name="currentProducts" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Product" inverseName="list" inverseEntity="Product"/>
-        <relationship name="removedProducts" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Product" inverseName="removedList" inverseEntity="Product"/>
+        <relationship name="sections" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Section" inverseName="list" inverseEntity="Section"/>
     </entity>
     <entity name="Product" representedClassName=".Product" syncable="YES">
         <attribute name="name" attributeType="String"/>
         <attribute name="quantity" attributeType="String"/>
-        <attribute name="removedIndex" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="removedRow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="barcode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Barcode" inverseName="product" inverseEntity="Barcode"/>
-        <relationship name="list" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="List" inverseName="currentProducts" inverseEntity="List"/>
-        <relationship name="removedList" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="List" inverseName="removedProducts" inverseEntity="List"/>
+        <relationship name="removedSection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="removedProducts" inverseEntity="Section"/>
+        <relationship name="section" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="products" inverseEntity="Section"/>
+    </entity>
+    <entity name="Section" representedClassName="Section" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <relationship name="list" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="List" inverseName="sections" inverseEntity="List"/>
+        <relationship name="products" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Product" inverseName="section" inverseEntity="Product"/>
+        <relationship name="removedProducts" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Product" inverseName="removedSection" inverseEntity="Product"/>
     </entity>
     <elements>
         <element name="Barcode" positionX="-45" positionY="27" width="128" height="103"/>
-        <element name="List" positionX="-431.8515625" positionY="-108.4453125" width="128" height="118"/>
+        <element name="List" positionX="-431.8515625" positionY="-108.4453125" width="128" height="88"/>
         <element name="Product" positionX="-311.69140625" positionY="196.33984375" width="128" height="133"/>
+        <element name="Section" positionX="-234" positionY="45" width="128" height="103"/>
     </elements>
 </model>

--- a/Grocery Geek/Core Data/Product+CoreDataClass.swift
+++ b/Grocery Geek/Core Data/Product+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Product+CoreDataClass.swift
 //  Grocery Geek
 //
-//  Created by Micah Beech on 2020-09-23.
+//  Created by Micah Beech on 2020-09-28.
 //  Copyright © 2020 Micah Beech. All rights reserved.
 //
 //

--- a/Grocery Geek/Core Data/Product+CoreDataProperties.swift
+++ b/Grocery Geek/Core Data/Product+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Product+CoreDataProperties.swift
 //  Grocery Geek
 //
-//  Created by Micah Beech on 2020-09-23.
+//  Created by Micah Beech on 2020-09-28.
 //  Copyright © 2020 Micah Beech. All rights reserved.
 //
 //
@@ -17,12 +17,12 @@ extension Product {
         return NSFetchRequest<Product>(entityName: "Product")
     }
 
-    @NSManaged public var removedIndex: Int32
     @NSManaged public var name: String?
     @NSManaged public var quantity: String?
+    @NSManaged public var removedRow: Int32
     @NSManaged public var barcode: Barcode?
-    @NSManaged public var list: List?
-    @NSManaged public var removedList: List?
+    @NSManaged public var removedSection: Section?
+    @NSManaged public var section: Section?
 
 }
 

--- a/Grocery Geek/Core Data/Section+CoreDataClass.swift
+++ b/Grocery Geek/Core Data/Section+CoreDataClass.swift
@@ -1,5 +1,5 @@
 //
-//  Barcode+CoreDataClass.swift
+//  Section+CoreDataClass.swift
 //  Grocery Geek
 //
 //  Created by Micah Beech on 2020-09-28.
@@ -10,7 +10,7 @@
 import Foundation
 import CoreData
 
-
-public class Barcode: NSManagedObject {
+@objc(Section)
+public class Section: NSManagedObject {
 
 }

--- a/Grocery Geek/Core Data/Section+CoreDataProperties.swift
+++ b/Grocery Geek/Core Data/Section+CoreDataProperties.swift
@@ -1,0 +1,99 @@
+//
+//  Section+CoreDataProperties.swift
+//  Grocery Geek
+//
+//  Created by Micah Beech on 2020-09-28.
+//  Copyright © 2020 Micah Beech. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Section {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Section> {
+        return NSFetchRequest<Section>(entityName: "Section")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var list: List?
+    @NSManaged public var products: NSOrderedSet?
+    @NSManaged public var removedProducts: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for products
+extension Section {
+
+    @objc(insertObject:inProductsAtIndex:)
+    @NSManaged public func insertIntoProducts(_ value: Product, at idx: Int)
+
+    @objc(removeObjectFromProductsAtIndex:)
+    @NSManaged public func removeFromProducts(at idx: Int)
+
+    @objc(insertProducts:atIndexes:)
+    @NSManaged public func insertIntoProducts(_ values: [Product], at indexes: NSIndexSet)
+
+    @objc(removeProductsAtIndexes:)
+    @NSManaged public func removeFromProducts(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInProductsAtIndex:withObject:)
+    @NSManaged public func replaceProducts(at idx: Int, with value: Product)
+
+    @objc(replaceProductsAtIndexes:withProducts:)
+    @NSManaged public func replaceProducts(at indexes: NSIndexSet, with values: [Product])
+
+    @objc(addProductsObject:)
+    @NSManaged public func addToProducts(_ value: Product)
+
+    @objc(removeProductsObject:)
+    @NSManaged public func removeFromProducts(_ value: Product)
+
+    @objc(addProducts:)
+    @NSManaged public func addToProducts(_ values: NSOrderedSet)
+
+    @objc(removeProducts:)
+    @NSManaged public func removeFromProducts(_ values: NSOrderedSet)
+
+}
+
+// MARK: Generated accessors for removedProducts
+extension Section {
+
+    @objc(insertObject:inRemovedProductsAtIndex:)
+    @NSManaged public func insertIntoRemovedProducts(_ value: Product, at idx: Int)
+
+    @objc(removeObjectFromRemovedProductsAtIndex:)
+    @NSManaged public func removeFromRemovedProducts(at idx: Int)
+
+    @objc(insertRemovedProducts:atIndexes:)
+    @NSManaged public func insertIntoRemovedProducts(_ values: [Product], at indexes: NSIndexSet)
+
+    @objc(removeRemovedProductsAtIndexes:)
+    @NSManaged public func removeFromRemovedProducts(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInRemovedProductsAtIndex:withObject:)
+    @NSManaged public func replaceRemovedProducts(at idx: Int, with value: Product)
+
+    @objc(replaceRemovedProductsAtIndexes:withRemovedProducts:)
+    @NSManaged public func replaceRemovedProducts(at indexes: NSIndexSet, with values: [Product])
+
+    @objc(addRemovedProductsObject:)
+    @NSManaged public func addToRemovedProducts(_ value: Product)
+
+    @objc(removeRemovedProductsObject:)
+    @NSManaged public func removeFromRemovedProducts(_ value: Product)
+
+    @objc(addRemovedProducts:)
+    @NSManaged public func addToRemovedProducts(_ values: NSOrderedSet)
+
+    @objc(removeRemovedProducts:)
+    @NSManaged public func removeFromRemovedProducts(_ values: NSOrderedSet)
+
+}
+
+extension Section : Identifiable {
+
+}

--- a/Grocery Geek/Models/GroceryListManager.swift
+++ b/Grocery Geek/Models/GroceryListManager.swift
@@ -116,11 +116,15 @@ class GroceryListManager {
     @discardableResult
     func moveProduct(source: IndexPath, destination: IndexPath) -> Bool {
         
-        guard let section = getSection(index: source.section) else { return false }
+        guard let startSection = getSection(index: source.section) else { return false }
+        guard let endSection = getSection(index: destination.section) else { return false }
+        
         guard let product = getProduct(indexPath: source) else { return false }
 
-        section.removeFromProducts(at: source.row)
-        section.insertIntoProducts(product, at: destination.row)
+        if destination.row > endSection.products!.count { return false }
+        
+        startSection.removeFromProducts(at: source.row)
+        endSection.insertIntoProducts(product, at: destination.row)
         
         return true
         
@@ -142,7 +146,7 @@ class GroceryListManager {
     }
     
     func sectionSize(sectionIndex: Int) -> Int {
-        let section = list.sections!.array[sectionIndex] as! Section
+        guard let section = getSection(index: sectionIndex) else { return 0 }
         return section.products!.count
     }
     

--- a/Grocery Geek/Models/GroceryListManager.swift
+++ b/Grocery Geek/Models/GroceryListManager.swift
@@ -20,7 +20,7 @@ class GroceryListManager {
     }
     
     @discardableResult
-    func addListProduct(name: String, quantity: String?, barcode: Barcode?) -> Product {
+    func addListProduct(section: Int, name: String, quantity: String?, barcode: Barcode?) -> Product? {
         
         // add product to core data
         let entity = NSEntityDescription.entity(forEntityName: "Product", in: context)
@@ -36,7 +36,8 @@ class GroceryListManager {
         newProduct.barcode?.quantity = newProduct.quantity
         
         // add product to the list
-        list.addToCurrentProducts(newProduct)
+        guard let section = getSection(index: section) else { return nil }
+        section.addToProducts(newProduct)
         
         return newProduct
     }
@@ -46,7 +47,7 @@ class GroceryListManager {
         // update product properties
         product.name = name
         product.quantity = quantity
-        
+
         // update info for the barcode
         product.barcode?.name = name
         product.barcode?.quantity = quantity
@@ -54,56 +55,60 @@ class GroceryListManager {
     }
     
     @discardableResult
-    func removeProduct(index: Int) -> Bool {
-        
-        if 0 > index || index >= list.currentProducts!.count {
-            return false
-        }
+    func removeProduct(indexPath: IndexPath) -> Bool {
         
         // get product to remove
-        let removedProduct = list.currentProducts?.array[index] as! Product
-        removedProduct.removedIndex = Int32(index)
-        
+        guard let section = getSection(index: indexPath.section) else { return false }
+        guard let removedProduct = getProduct(indexPath: indexPath) else { return false }
+        removedProduct.removedSection = section
+        removedProduct.removedRow = Int32(indexPath.row)
+
         // move product
-        list.addToRemovedProducts(removedProduct)
-        list.removeFromCurrentProducts(removedProduct)
+        section.removeFromProducts(removedProduct)
+        section.addToRemovedProducts(removedProduct)
         
         return true
         
     }
     
-    func undoRemoveProduct() -> Bool {
+    func undoRemoveProduct(section: Int) -> Bool {
         
         // Get place of item to remove
-        let itemIndex = list.removedProducts!.count - 1
-        
+        guard let section = getSection(index: section) else { return false }
+        let itemIndex = section.removedProducts!.count - 1
+
         // do nothing if nothing to remove
         if itemIndex < 0 {
             return false
         }
-        
+
         // get removed product
-        let product = list.removedProducts?.array[itemIndex] as! Product
-        
+        let product = section.removedProducts?.array[itemIndex] as! Product
+
         // move product
-        list.insertIntoCurrentProducts(product, at: Int(product.removedIndex))
-        list.removeFromRemovedProducts(product)
+        section.insertIntoProducts(product, at: Int(product.removedRow))
+        section.removeFromRemovedProducts(product)
         
         return true
     }
     
     func clearList() {
-        
-        // delete removed products
-        for product in list.removedProducts?.array as! [Product] {
-            list.removeFromRemovedProducts(product)
-            context.delete(product)
-        }
-        
+
         // delete from list
-        for product in list.currentProducts?.array as! [Product] {
-            list.removeFromCurrentProducts(product)
-            context.delete(product)
+        for section in list.sections?.array as! [Section] {
+            
+            for product in section.products?.array as! [Product] {
+                section.removeFromProducts(product)
+                context.delete(product)
+            }
+            
+            for product in section.removedProducts?.array as! [Product] {
+                section.removeFromRemovedProducts(product)
+                context.delete(product)
+            }
+            
+            list.removeFromSections(section)
+            context.delete(section)
         }
         
     }
@@ -111,32 +116,92 @@ class GroceryListManager {
     @discardableResult
     func moveProduct(source: IndexPath, destination: IndexPath) -> Bool {
         
-        if 0 > source.row || source.row >= list.currentProducts!.count ||
-           0 > destination.row || destination.row >= list.currentProducts!.count {
-            return false
-        }
-        
-        let product = list.currentProducts?.array[source.row] as! Product
-        list.removeFromCurrentProducts(at: source.row)
-        list.insertIntoCurrentProducts(product, at: destination.row)
+        guard let section = getSection(index: source.section) else { return false }
+        guard let product = getProduct(indexPath: source) else { return false }
+
+        section.removeFromProducts(at: source.row)
+        section.insertIntoProducts(product, at: destination.row)
         
         return true
         
     }
     
     func hasProducts() -> Bool {
-        return list.currentProducts!.count > 0 || list.removedProducts!.count > 0
+        
+        for section in list.sections!.array as! [Section] {
+            if section.products!.count > 0 || section.removedProducts!.count > 0 {
+                return true
+            }
+        }
+        
+        return false
     }
     
-    func size() -> Int {
-        return list.currentProducts!.count
+    func sectionCount() -> Int {
+        return list.sections!.count
     }
     
-    func getProduct(index: Int) -> Product? {
-        if 0 > index || index >= list.currentProducts!.count {
+    func sectionSize(sectionIndex: Int) -> Int {
+        let section = list.sections!.array[sectionIndex] as! Section
+        return section.products!.count
+    }
+    
+    func getSection(index: Int) -> Section? {
+        
+        if 0 > index || index >= list.sections!.count {
             return nil
         }
-        return list.currentProducts?.array[index] as? Product
+        
+        return list.sections?.array[index] as? Section
+    }
+    
+    func getProduct(indexPath: IndexPath) -> Product? {
+        
+        guard let section = getSection(index: indexPath.section) else { return nil }
+        
+        if 0 > indexPath.row || indexPath.row >= section.products!.count {
+            return nil
+        }
+        
+        return section.products?.array[indexPath.row] as? Product
+        
+    }
+    
+    @discardableResult
+    func addSection(name: String) -> Section {
+        // add product to core data
+        let entity = NSEntityDescription.entity(forEntityName: "Section", in: context)
+        let newSection = NSManagedObject(entity: entity!, insertInto: context) as! Section
+         
+        // set the product's properties
+        newSection.name = name
+        
+        list.addToSections(newSection)
+        
+        return newSection
+    }
+    
+    @discardableResult
+    func editSection(section: Int, name: String) -> Bool {
+        
+        guard let section = getSection(index: section) else { return false }
+        
+        section.name = name
+        
+        return true
+        
+    }
+    
+    @discardableResult
+    func deleteSection(section: Int) -> Bool {
+        
+        guard let section = getSection(index: section) else { return false }
+        
+        list.removeFromSections(section)
+        context.delete(section)
+        
+        return true
+        
     }
     
 }

--- a/Grocery Geek/Models/ListTableManager.swift
+++ b/Grocery Geek/Models/ListTableManager.swift
@@ -86,8 +86,10 @@ class ListTableManager {
         
         // Set fields
         list.name = name
-        list.id = UUID()
         list.index = Int32(lists.count)
+        
+        let listManager = GroceryListManager(context: context, list: list)
+        listManager.addSection(name: "Items")
         
         // Add to list of lists
         lists.append(list)

--- a/Grocery Geek/View Controllers/AddViewController.swift
+++ b/Grocery Geek/View Controllers/AddViewController.swift
@@ -16,6 +16,7 @@ class AddViewController: UIViewController, UITextFieldDelegate {
     var itemToEdit: Product?
     var list: List!
     var listManager: GroceryListManager!
+    var section: Int?
     
     @IBOutlet weak var toolbar: UIToolbar!
     @IBOutlet weak var toolbarHeight: NSLayoutConstraint!
@@ -141,7 +142,7 @@ class AddViewController: UIViewController, UITextFieldDelegate {
             
         } else {
             
-            listManager.addListProduct(name: productName.text!, quantity: productQuantity.text, barcode: barcodeProduct)
+            listManager.addListProduct(section: section!, name: productName.text!, quantity: productQuantity.text, barcode: barcodeProduct)
             
         }
         

--- a/Grocery Geek/View Controllers/GroceryListTableView.swift
+++ b/Grocery Geek/View Controllers/GroceryListTableView.swift
@@ -18,13 +18,135 @@ extension ListViewController : UITableViewDelegate, UITableViewDataSource {
         groceryList.dataSource = self
     }
     
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return listManager.sectionCount()
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return listManager.size()
+        return listManager.sectionSize(sectionIndex: section)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return headerSize
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        
+        let sectionObject = listManager.getSection(index: section)
+        
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: tableView.rowHeight))
+        view.backgroundColor = UIColor.systemBackground
+        
+        let itemHeight = CGFloat(44)
+        let inset = CGFloat(15)
+        let offset = (headerSize - itemHeight) / 2
+        
+        let title = UILabel(frame: CGRect(x: inset, y: offset, width: view.frame.width - (itemHeight + inset) * 3 - inset, height: itemHeight))
+        title.text = sectionObject?.name
+        title.font = UIFont(descriptor: title.font.fontDescriptor, size: 30)
+        
+        view.addSubview(title)
+        
+        // When in editing mode, the section shows a button to delete it and edit its name
+        if tableView.isEditing {
+            
+            let deleteButton = UIButton(frame: CGRect(x: view.frame.maxX - inset - itemHeight, y: offset, width: itemHeight, height: itemHeight))
+            deleteButton.setImage(UIImage(systemName: "minus.circle"), for: .normal)
+            deleteButton.addTarget(self, action: #selector(deleteSection), for: .touchUpInside)
+            deleteButton.tag = section
+            
+            let editButton = UIButton(frame: CGRect(x: deleteButton.frame.minX - inset - itemHeight, y: offset, width: itemHeight, height: itemHeight))
+            editButton.setImage(UIImage(systemName: "rectangle.and.pencil.and.ellipsis"), for: .normal)
+            editButton.addTarget(self, action: #selector(editHeader), for: .touchUpInside)
+            editButton.tag = section
+            
+            view.addSubview(deleteButton)
+            view.addSubview(editButton)
+        
+        // Otherwise, the section has buttons to add, scan and undo removing products
+        } else {
+            
+            let addButton = UIButton(frame: CGRect(x: view.frame.maxX - inset - itemHeight, y: offset, width: itemHeight, height: itemHeight))
+            addButton.setImage(UIImage(systemName: "plus"), for: .normal)
+            addButton.addTarget(self, action: #selector(addProduct), for: .touchUpInside)
+            addButton.tag = section
+            
+            let scanButton = UIButton(frame: CGRect(x: addButton.frame.minX - inset - itemHeight, y: offset, width: itemHeight, height: itemHeight))
+            scanButton.setImage(UIImage(systemName: "barcode.viewfinder"), for: .normal)
+            scanButton.addTarget(self, action: #selector(scanProduct), for: .touchUpInside)
+            scanButton.tag = section
+            
+            let undoButton = UIButton(frame: CGRect(x: scanButton.frame.minX - inset - itemHeight, y: offset, width: itemHeight, height: itemHeight))
+            undoButton.setImage(UIImage(systemName: "arrow.uturn.left"), for: .normal)
+            undoButton.addTarget(self, action: #selector(undoRemove), for: .touchUpInside)
+            undoButton.tag = section
+            
+            view.addSubview(addButton)
+            view.addSubview(scanButton)
+            view.addSubview(undoButton)
+            
+        }
+        
+        return view
+    }
+    
+    // Selector function for adding a product
+    @objc func addProduct(sender: UIButton!) {
+        selectedSection = sender.tag
+        performSegue(withIdentifier: "addProduct", sender: self)
+    }
+    
+    // Selector function for scanning a product
+    @objc func scanProduct(sender: UIButton!) {
+        selectedSection = sender.tag
+        performSegue(withIdentifier: "scanProduct", sender: self)
+    }
+    
+    // Selector function for editing a section name
+    @objc func editHeader(sender: UIButton!) {
+        let section = listManager.getSection(index: sender.tag)
+        changeSectionName(title: "Edit section", message: nil, name: section?.name, section: sender.tag)
+    }
+    
+    // Selector function for deleting a section
+    @objc func deleteSection(sender: UIButton!) {
+        
+        // construct alert to be displayed
+        let alert = UIAlertController(title: "Delete section?", message: "This cannot be undone", preferredStyle: .alert)
+        
+        // execute if confirmation received
+        alert.addAction(UIAlertAction(title: "Ok", style: .destructive, handler: { action in
+            self.listManager.deleteSection(section: sender.tag)
+            self.groceryList.reloadData()
+        }))
+        
+        // execute if event cancelled
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        present(alert, animated: true, completion: nil)
+        
+    }
+    
+    // Selector function for undoing the removal of a product
+    @objc func undoRemove(sender: UIButton!) {
+        
+        if listManager.undoRemoveProduct(section: sender.tag) {
+            groceryList.reloadData()
+            return
+        }
+        
+        // construct alert to be displayed
+        let alert = UIAlertController(title: "No items have been removed", message: "Swipe left to remove an item", preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        
+        present(alert, animated: true, completion: nil)
+        
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // Get the data for this row
-        let product = listManager.getProduct(index: indexPath.row)
+        let product = listManager.getProduct(indexPath: indexPath)
         
         // Get a cell to display
         let cell = tableView.dequeueReusableCell(withIdentifier: "ProductItem", for: indexPath) as! GroceryItem
@@ -35,14 +157,15 @@ extension ListViewController : UITableViewDelegate, UITableViewDataSource {
         return cell
     }
     
+    // Go into product editing mode when a row is selected
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        selectedRow = listManager.getProduct(index: indexPath.row)
+        selectedRow = listManager.getProduct(indexPath: indexPath)
         performSegue(withIdentifier: "addProduct", sender: self)
     }
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            listManager.removeProduct(index: indexPath.row)
+            listManager.removeProduct(indexPath: indexPath)
             groceryList.reloadData()
         }
     }

--- a/Grocery Geek/View Controllers/ListViewController.swift
+++ b/Grocery Geek/View Controllers/ListViewController.swift
@@ -152,7 +152,7 @@ class ListViewController: UIViewController {
     
     @IBAction func addSection(_ sender: Any) {
         
-        changeSectionName(title: "Add section")
+        changeSectionName(title: "Add section", message: "Use sections to group your lists into product types!")
         
     }
     

--- a/Grocery Geek/View Controllers/ListViewController.swift
+++ b/Grocery Geek/View Controllers/ListViewController.swift
@@ -19,6 +19,9 @@ class ListViewController: UIViewController {
     var listManager: GroceryListManager!
     
     var selectedRow: Product?
+    var selectedSection: Int?
+    
+    let headerSize = CGFloat(60)
     
     // MARK: setup
     
@@ -39,11 +42,14 @@ class ListViewController: UIViewController {
             let destinationVC = segue.destination as! AddViewController
             destinationVC.list = list
             destinationVC.itemToEdit = selectedRow
+            destinationVC.section = selectedSection
             selectedRow = nil
+            selectedSection = nil
             
         case "scanProduct":
             let destinationVC = segue.destination as! ScannerViewController
             destinationVC.list = list
+            destinationVC.section = selectedSection
             
         default:
             break
@@ -56,6 +62,8 @@ class ListViewController: UIViewController {
     @IBAction func editToggle(_ sender: Any) {
         groceryList.isEditing = !groceryList.isEditing
         
+        groceryList.reloadData()
+        
         if groceryList.isEditing {
             editButton.title = "Done"
             editButton.style = .done
@@ -63,21 +71,6 @@ class ListViewController: UIViewController {
             editButton.title = "Edit"
             editButton.style = .plain
         }
-    }
-        
-    @IBAction func undoRemove(_ sender: Any) {
-        
-        if listManager.undoRemoveProduct() {
-            groceryList.reloadData()
-            return
-        }
-        
-        // construct alert to be displayed
-        let alert = UIAlertController(title: "No items have been removed", message: "Swipe left to remove an item", preferredStyle: .alert)
-        
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        
-        present(alert, animated: true, completion: nil)
     }
     
     // MARK: Clear data
@@ -107,7 +100,7 @@ class ListViewController: UIViewController {
         } else {
             
             // construct alert to be displayed
-            let alert = UIAlertController(title: "Your list is empty!", message: "Scan or add items from the toolbar below.", preferredStyle: .alert)
+            let alert = UIAlertController(title: "Your list is empty!", message: "Scan or add items to build your list.", preferredStyle: .alert)
             
             // add action
             alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
@@ -116,6 +109,53 @@ class ListViewController: UIViewController {
             
         }
     }
+    
+    func changeSectionName(title: String, message: String? = nil, name: String? = nil, section: Int? = nil) {
+        
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        var listNameField = UITextField()
+        
+        alert.addTextField { (textField) in
+            textField.placeholder = "Name"
+            textField.autocapitalizationType = .sentences
+            textField.text = name
+            listNameField = textField
+        }
+        
+        let add = UIAlertAction(title: "OK", style: .default) { (action) in
+            if listNameField.text == nil || listNameField.text == "" {
+                return
+            }
+            
+            if name == nil {
+                self.listManager.addSection(name: listNameField.text!)
+            } else {
+                self.listManager.editSection(section: section!, name: listNameField.text!)
+            }
+            
+            self.groceryList.reloadData()
+        }
+        
+        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        
+        alert.addAction(add)
+        alert.addAction(cancel)
+        
+        present(alert, animated: true)
+        
+    }
+    
+    @IBAction func addSection(_ sender: Any) {
+        
+        changeSectionName(title: "Add section")
+        
+    }
+    
     
 }
 

--- a/Grocery Geek/View Controllers/ScanViewController.swift
+++ b/Grocery Geek/View Controllers/ScanViewController.swift
@@ -20,6 +20,7 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
     var barcodeProduct: Barcode?
     var list: List!
     var barcodeManager: BarcodeManager!
+    var section: Int!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -123,6 +124,7 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
             let destinationVC = segue.destination as! AddViewController
             destinationVC.barcodeProduct = self.barcodeProduct
             destinationVC.list = self.list
+            destinationVC.section = section
             
         default:
             break

--- a/Grocery GeekTests/BarcodeManagerTests.swift
+++ b/Grocery GeekTests/BarcodeManagerTests.swift
@@ -54,5 +54,28 @@ class BarcodeManagerTests : XCTestCase {
         XCTAssert(barcode1 == barcode2)
         
     }
+    
+    func testSave() {
+        
+        expectation(forNotification: .NSManagedObjectContextDidSave, object: coreDataHelper.persistentContainer.viewContext) { _ in
+            return true
+        }
+        
+        let code = UUID().uuidString
+        let barcode = barcodeManager.findProduct(code: code)
+        coreDataHelper.saveContext()
+        
+        waitForExpectations(timeout: 2.0) { error in
+            XCTAssertNil(error, "Save did not occur")
+            
+            let newManager = BarcodeManager(context: self.coreDataHelper.persistentContainer.viewContext)
+            let newBarcode = newManager.findProduct(code: code)
+            
+            XCTAssertNotNil(newBarcode)
+            XCTAssert(newBarcode == barcode)
+            
+        }
+        
+    }
 
 }

--- a/Grocery GeekTests/GroceryListManagerTests.swift
+++ b/Grocery GeekTests/GroceryListManagerTests.swift
@@ -20,9 +20,9 @@ class GroceryListManagerTests : XCTestCase {
         coreDataHelper = CoreDataTestHelper()
         
         let context = coreDataHelper.persistentContainer.viewContext
-        let entity = NSEntityDescription.entity(forEntityName: "List", in: context)
-        let list = NSManagedObject(entity: entity!, insertInto: context) as! List
-        list.id = UUID()
+        
+        let listEntity = NSEntityDescription.entity(forEntityName: "List", in: context)
+        let list = NSManagedObject(entity: listEntity!, insertInto: context) as! List
         list.name = "List"
         list.index = 0
         
@@ -35,18 +35,46 @@ class GroceryListManagerTests : XCTestCase {
         groceryListManager = nil
     }
     
+    func testAddSection() {
+        
+        let section = groceryListManager.addSection(name: "Section")
+        
+        XCTAssertNotNil(section.name)
+        XCTAssertNotNil(section.products)
+        XCTAssert(section.name == "Section")
+        XCTAssert(section.products!.count == 0)
+        XCTAssert(groceryListManager.list.sections?.count == 1)
+        XCTAssert(groceryListManager.list.sections?.firstObject as! Section == section)
+        
+    }
+    
+    func testDeleteSection() {
+        
+        groceryListManager.addSection(name: "Section")
+        let result1 = groceryListManager.deleteSection(section: 0)
+        let result2 = groceryListManager.deleteSection(section: 0)
+        
+        XCTAssertTrue(result1)
+        XCTAssertFalse(result2)
+        XCTAssert(groceryListManager.list.sections?.count == 0)
+        
+    }
+    
     func testAddListProductNoBarcode() {
         
-        let product = groceryListManager.addListProduct(name: "Product", quantity: "Quantity", barcode: nil)
+        let section = groceryListManager.addSection(name: "Section")
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: "Quantity", barcode: nil)
         
-        XCTAssertNotNil(product.name)
-        XCTAssertNotNil(product.quantity)
-        XCTAssert(product.name == "Product")
-        XCTAssert(product.quantity == "Quantity")
-        XCTAssertNil(product.barcode)
-        XCTAssert(groceryListManager.list.currentProducts?.count == 1)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 0)
-        XCTAssert(groceryListManager.list.currentProducts?.firstObject as! Product == product)
+        XCTAssertNotNil(product)
+        XCTAssertNotNil(product!.name)
+        XCTAssertNotNil(product!.quantity)
+        XCTAssert(product!.name == "Product")
+        XCTAssert(product!.quantity == "Quantity")
+        XCTAssertNil(product!.barcode)
+        XCTAssert(section.products?.count == 1)
+        XCTAssert(section.removedProducts?.count == 0)
+        XCTAssert(section.products?.firstObject as? Product == product)
+        
     }
     
     func testAddListProductWithBarcode() {
@@ -55,106 +83,137 @@ class GroceryListManagerTests : XCTestCase {
         let entity = NSEntityDescription.entity(forEntityName: "Barcode", in: context)
         let barcode = NSManagedObject(entity: entity!, insertInto: context) as! Barcode
         
-        let product = groceryListManager.addListProduct(name: "Product", quantity: "Quantity", barcode: barcode)
+        let section = groceryListManager.addSection(name: "Section")
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: "Quantity", barcode: barcode)
         
-        XCTAssertNotNil(product.name)
-        XCTAssertNotNil(product.quantity)
-        XCTAssertNotNil(product.barcode)
-        XCTAssert(product.name == "Product")
-        XCTAssert(product.quantity == "Quantity")
-        XCTAssert(product.barcode == barcode)
-        XCTAssertNotNil(product.barcode?.name)
-        XCTAssertNotNil(product.barcode?.quantity)
-        XCTAssert(product.barcode?.name == product.name)
-        XCTAssert(product.barcode?.quantity == product.quantity)
-        XCTAssert(groceryListManager.list.currentProducts?.count == 1)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 0)
-        XCTAssert(groceryListManager.list.currentProducts?.firstObject as! Product == product)
+        XCTAssertNotNil(product)
+        XCTAssertNotNil(product!.name)
+        XCTAssertNotNil(product!.quantity)
+        XCTAssertNotNil(product!.barcode)
+        XCTAssert(product!.name == "Product")
+        XCTAssert(product!.quantity == "Quantity")
+        XCTAssert(product!.barcode == barcode)
+        XCTAssertNotNil(product!.barcode?.name)
+        XCTAssertNotNil(product!.barcode?.quantity)
+        XCTAssert(product!.barcode?.name == product!.name)
+        XCTAssert(product!.barcode?.quantity == product!.quantity)
+        XCTAssert(section.products?.count == 1)
+        XCTAssert(section.removedProducts?.count == 0)
+        XCTAssert(section.products?.firstObject as? Product == product)
+        
+    }
+    
+    func testAddProductBadSection() {
+        
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: "Quantity", barcode: nil)
+        
+        XCTAssertNil(product)
         
     }
     
     func testEditProduct() {
         
-        let product = groceryListManager.addListProduct(name: "Product", quantity: "Quantity", barcode: nil)
-        let barcode = product.barcode
+        groceryListManager.addSection(name: "Section")
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: "Quantity", barcode: nil)
         
-        groceryListManager.editProduct(product: product, name: "New name", quantity: "New quantity")
+        XCTAssertNotNil(product)
         
-        XCTAssertNotNil(product.name)
-        XCTAssertNotNil(product.quantity)
-        XCTAssert(product.name == "New name")
-        XCTAssert(product.quantity == "New quantity")
-        XCTAssert(product.barcode == barcode)
+        let barcode = product!.barcode
+        
+        groceryListManager.editProduct(product: product!, name: "New name", quantity: "New quantity")
+        
+        XCTAssertNotNil(product!.name)
+        XCTAssertNotNil(product!.quantity)
+        XCTAssert(product!.name == "New name")
+        XCTAssert(product!.quantity == "New quantity")
+        XCTAssert(product!.barcode == barcode)
         
     }
     
     func testRemoveProductFailure() {
         
-        let result = groceryListManager.removeProduct(index: 0)
+        let bad = groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
         
-        XCTAssertFalse(result)
+        groceryListManager.addSection(name: "Section")
+        
+        let badSection = groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 1))
+        let badRow = groceryListManager.removeProduct(indexPath: IndexPath(row: 1, section: 0))
+        
+        XCTAssertFalse(bad)
+        XCTAssertFalse(badSection)
+        XCTAssertFalse(badRow)
         
     }
     
     func testRemoveProduct() {
         
-        let product = groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
+        let section = groceryListManager.addSection(name: "Section")
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
         
-        groceryListManager.removeProduct(index: 0)
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
         
-        XCTAssert(product.removedIndex == 0)
-        XCTAssert(groceryListManager.list.currentProducts?.count == 0)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 1)
-        XCTAssert(groceryListManager.list.removedProducts?.firstObject as! Product == product)
+        XCTAssert(product?.removedRow == 0)
+        XCTAssert(section.products?.count == 0)
+        XCTAssert(section.removedProducts?.count == 1)
+        XCTAssert(section.removedProducts?.firstObject as? Product == product)
         
     }
     
     func testUndoRemoveProductFailure() {
         
-        let result = groceryListManager.undoRemoveProduct()
+        let bad = groceryListManager.undoRemoveProduct(section: 0)
         
-        XCTAssertFalse(result)
+        groceryListManager.addSection(name: "Section")
+        
+        let badRow = groceryListManager.undoRemoveProduct(section: 0)
+        let badSection = groceryListManager.undoRemoveProduct(section: 1)
+        
+        XCTAssertFalse(bad)
+        XCTAssertFalse(badRow)
+        XCTAssertFalse(badSection)
         
     }
     
     func testUndoRemoveProduct() {
 
-        let product = groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        groceryListManager.removeProduct(index: 0)
-        let result = groceryListManager.undoRemoveProduct()
+        let section = groceryListManager.addSection(name: "Section")
+        let product = groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
+        let result = groceryListManager.undoRemoveProduct(section: 0)
         
         XCTAssertTrue(result)
-        XCTAssert(groceryListManager.list.currentProducts?.count == 1)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 0)
-        XCTAssert(groceryListManager.list.currentProducts?.firstObject as! Product == product)
+        XCTAssert(section.products?.count == 1)
+        XCTAssert(section.removedProducts?.count == 0)
+        XCTAssert(section.products?.firstObject as? Product == product)
         
     }
     
     func testUndoRemoveProductCorrectIndex() {
         
-        let product1 = groceryListManager.addListProduct(name: "Product 1", quantity: nil, barcode: nil)
-        let product2 = groceryListManager.addListProduct(name: "Product 2", quantity: nil, barcode: nil)
-        let product3 = groceryListManager.addListProduct(name: "Product 3", quantity: nil, barcode: nil)
+        let section = groceryListManager.addSection(name: "Section")
+        let product1 = groceryListManager.addListProduct(section: 0, name: "Product 1", quantity: nil, barcode: nil)
+        let product2 = groceryListManager.addListProduct(section: 0, name: "Product 2", quantity: nil, barcode: nil)
+        let product3 = groceryListManager.addListProduct(section: 0, name: "Product 3", quantity: nil, barcode: nil)
         
-        groceryListManager.removeProduct(index: 1)
-        let result = groceryListManager.undoRemoveProduct()
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 1, section: 0))
+        let result = groceryListManager.undoRemoveProduct(section: 0)
         
         XCTAssertTrue(result)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 0)
-        XCTAssert(groceryListManager.list.currentProducts?.array as! [Product] == [product1, product2, product3])
+        XCTAssert(section.removedProducts?.count == 0)
+        XCTAssert(section.products?.array as! [Product] == [product1, product2, product3])
         
     }
     
     func testClearList() {
         
-        groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        groceryListManager.removeProduct(index: 0)
+        groceryListManager.addSection(name: "Section")
+        groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
         
         groceryListManager.clearList()
         
-        XCTAssert(groceryListManager.list.currentProducts?.count == 0)
-        XCTAssert(groceryListManager.list.removedProducts?.count == 0)
+        XCTAssert(groceryListManager.list.sections?.count == 0)
         
     }
     
@@ -166,66 +225,135 @@ class GroceryListManagerTests : XCTestCase {
         
     }
     
-    func testMoveProduct() {
+    func testMoveProductSameSection() {
         
-        let product1 = groceryListManager.addListProduct(name: "Product 1", quantity: nil, barcode: nil)
-        let product2 = groceryListManager.addListProduct(name: "Product 2", quantity: nil, barcode: nil)
-        let product3 = groceryListManager.addListProduct(name: "Product 3", quantity: nil, barcode: nil)
+        let section = groceryListManager.addSection(name: "Section")
+        let product1 = groceryListManager.addListProduct(section: 0, name: "Product 1", quantity: nil, barcode: nil)
+        let product2 = groceryListManager.addListProduct(section: 0, name: "Product 2", quantity: nil, barcode: nil)
+        let product3 = groceryListManager.addListProduct(section: 0, name: "Product 3", quantity: nil, barcode: nil)
         
-        let original = groceryListManager.list.currentProducts?.array as? [Product]
+        let original = section.products?.array as? [Product]
         
         let result1 = groceryListManager.moveProduct(source: IndexPath(row: 0, section: 0), destination: IndexPath(row: 2, section: 0))
         let result2 = groceryListManager.moveProduct(source: IndexPath(row: 1, section: 0), destination: IndexPath(row: 0, section: 0))
         
+        XCTAssertNotNil(product1)
+        XCTAssertNotNil(product2)
+        XCTAssertNotNil(product3)
         XCTAssertTrue(result1)
         XCTAssertTrue(result2)
-        XCTAssert(original == [product1, product2, product3])
-        XCTAssert(groceryListManager.list.currentProducts?.array as? [Product] == [product3, product2, product1])
+        XCTAssert(original == [product1!, product2!, product3!])
+        XCTAssert(section.products?.array as? [Product] == [product3!, product2!, product1!])
+
+    }
+    
+    func testMoveProductDifferentSection() {
+        
+        let section1 = groceryListManager.addSection(name: "Section 1")
+        let section2 = groceryListManager.addSection(name: "Section 2")
+        let product1 = groceryListManager.addListProduct(section: 0, name: "Product 1", quantity: nil, barcode: nil)
+        let product2 = groceryListManager.addListProduct(section: 0, name: "Product 2", quantity: nil, barcode: nil)
+        let product3 = groceryListManager.addListProduct(section: 1, name: "Product 3", quantity: nil, barcode: nil)
+        
+        let original1 = section1.products?.array as? [Product]
+        let original2 = section2.products?.array as? [Product]
+        
+        let result1 = groceryListManager.moveProduct(source: IndexPath(row: 0, section: 0), destination: IndexPath(row: 1, section: 1))
+        let result2 = groceryListManager.moveProduct(source: IndexPath(row: 0, section: 1), destination: IndexPath(row: 0, section: 0))
+        
+        XCTAssertNotNil(product1)
+        XCTAssertNotNil(product2)
+        XCTAssertNotNil(product3)
+        XCTAssertTrue(result1)
+        XCTAssertTrue(result2)
+        XCTAssert(original1 == [product1!, product2!])
+        XCTAssert(original2 == [product3!])
+        XCTAssert(section1.products?.array as? [Product] == [product3!, product2!])
+        XCTAssert(section2.products?.array as? [Product] == [product1!])
 
     }
     
     func testHasProducts() {
         
         let result1 = groceryListManager.hasProducts()
-        groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
+        groceryListManager.addSection(name: "Section")
         let result2 = groceryListManager.hasProducts()
+        groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        let result3 = groceryListManager.hasProducts()
         
         XCTAssertFalse(result1)
-        XCTAssertTrue(result2)
+        XCTAssertFalse(result2)
+        XCTAssertTrue(result3)
         
     }
     
     func testSize() {
         
-        let empty1 = groceryListManager.size()
+        let noSections = groceryListManager.sectionCount()
+        let badProducts = groceryListManager.sectionSize(sectionIndex: 0)
         
-        groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        let one = groceryListManager.size()
+        groceryListManager.addSection(name: "Section")
+        let oneSection = groceryListManager.sectionCount()
+        let noProducts = groceryListManager.sectionSize(sectionIndex: 0)
         
-        groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        let two = groceryListManager.size()
+        groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        let oneProduct = groceryListManager.sectionSize(sectionIndex: 0)
         
-        groceryListManager.removeProduct(index: 0)
-        groceryListManager.removeProduct(index: 0)
-        let empty2 = groceryListManager.size()
+        groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        let twoProducts = groceryListManager.sectionSize(sectionIndex: 0)
         
-        XCTAssert(empty1 == 0)
-        XCTAssert(one == 1)
-        XCTAssert(two == 2)
-        XCTAssert(empty2 == 0)
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
+        let empty = groceryListManager.sectionSize(sectionIndex: 0)
+        
+        groceryListManager.deleteSection(section: 0)
+        let noSectionsAgain = groceryListManager.sectionCount()
+        
+        XCTAssert(noSections == 0)
+        XCTAssert(badProducts == 0)
+        XCTAssert(oneSection == 1)
+        XCTAssert(noProducts == 0)
+        XCTAssert(oneProduct == 1)
+        XCTAssert(twoProducts == 2)
+        XCTAssert(empty == 0)
+        XCTAssert(noSectionsAgain == 0)
+        
+    }
+    
+    func testGetSection() {
+        
+        let section1 = groceryListManager.getSection(index: 0)
+        let section2 = groceryListManager.addSection(name: "Section")
+        let section3 = groceryListManager.getSection(index: 0)
+        
+        XCTAssertNil(section1)
+        XCTAssertNotNil(section2)
+        XCTAssertNotNil(section3)
+        XCTAssert(section2 == section3)
         
     }
     
     func testGetProduct() {
         
-        let product1 = groceryListManager.getProduct(index: 0)
-        let product2 = groceryListManager.addListProduct(name: "Product", quantity: nil, barcode: nil)
-        let product3 = groceryListManager.getProduct(index: 0)
+        groceryListManager.addSection(name: "Section 1")
+        groceryListManager.addSection(name: "Section 2")
+        
+        let product1 = groceryListManager.getProduct(indexPath: IndexPath(row: 0, section: 0))
+        let product2 = groceryListManager.addListProduct(section: 0, name: "Product", quantity: nil, barcode: nil)
+        let product3 = groceryListManager.getProduct(indexPath: IndexPath(row: 0, section: 0))
+        
+        let product4 = groceryListManager.getProduct(indexPath: IndexPath(row: 0, section: 1))
+        let product5 = groceryListManager.addListProduct(section: 1, name: "Product", quantity: nil, barcode: nil)
+        let product6 = groceryListManager.getProduct(indexPath: IndexPath(row: 0, section: 1))
         
         XCTAssertNil(product1)
         XCTAssertNotNil(product2)
         XCTAssertNotNil(product3)
         XCTAssert(product2 == product3)
+        XCTAssertNil(product4)
+        XCTAssertNotNil(product5)
+        XCTAssertNotNil(product6)
+        XCTAssert(product5 == product6)
         
     }
     
@@ -239,10 +367,12 @@ class GroceryListManagerTests : XCTestCase {
         let entity = NSEntityDescription.entity(forEntityName: "Barcode", in: context)
         let barcode = NSManagedObject(entity: entity!, insertInto: context) as! Barcode
         
-        let product1 = groceryListManager.addListProduct(name: "Product 1", quantity: "1", barcode: barcode)
-        let product2 = groceryListManager.addListProduct(name: "Product 2", quantity: "2", barcode: nil)
+        let section = groceryListManager.addSection(name: "Section")
+        
+        let product1 = groceryListManager.addListProduct(section: 0, name: "Product 1", quantity: "1", barcode: barcode)
+        let product2 = groceryListManager.addListProduct(section: 0, name: "Product 2", quantity: "2", barcode: nil)
         groceryListManager.moveProduct(source: IndexPath(row: 0, section: 0), destination: IndexPath(row: 1, section: 0))
-        groceryListManager.removeProduct(index: 1)
+        groceryListManager.removeProduct(indexPath: IndexPath(row: 0, section: 0))
         
         coreDataHelper.saveContext()
         
@@ -251,15 +381,20 @@ class GroceryListManagerTests : XCTestCase {
             XCTAssertNil(error, "Save did not occur")
             
             let newManager = GroceryListManager(context: self.coreDataHelper.persistentContainer.viewContext, list: self.groceryListManager.list)
+            let newSection = newManager.list.sections?.firstObject as! Section
             
-            XCTAssert(newManager.list.currentProducts?.array as? [Product] == [product2])
-            XCTAssert(newManager.list.removedProducts?.array as? [Product] == [product1])
-            XCTAssert(product1.name == "Product 1")
-            XCTAssert(product2.name == "Product 2")
-            XCTAssert(product1.quantity == "1")
-            XCTAssert(product2.quantity == "2")
-            XCTAssert(product1.barcode == barcode)
-            XCTAssertNil(product2.barcode)
+            XCTAssertNotNil(newSection)
+            XCTAssert(newManager.list.sections?.array as? [Section] == [newSection])
+            XCTAssert(newSection.name == section.name)
+            XCTAssert(newSection.products?.array as? [Product] == [product1!])
+            XCTAssert(newSection.removedProducts?.array as? [Product] == [product2!])
+            XCTAssert(newSection.name == "Section")
+            XCTAssert(product1!.name == "Product 1")
+            XCTAssert(product2!.name == "Product 2")
+            XCTAssert(product1!.quantity == "1")
+            XCTAssert(product2!.quantity == "2")
+            XCTAssert(product1!.barcode == barcode)
+            XCTAssertNil(product2!.barcode)
             
         }
     }

--- a/Grocery GeekTests/ListTableManagerTests.swift
+++ b/Grocery GeekTests/ListTableManagerTests.swift
@@ -35,12 +35,11 @@ class ListTableManagerTests : XCTestCase {
         XCTAssertNotNil(list, "list should not be nil")
         XCTAssertNotNil(list.name, "list name should not be nil")
         XCTAssertNotNil(list.id, "id should not be nil")
-        XCTAssertNotNil(list.currentProducts, "current products should not be nil")
-        XCTAssertNotNil(list.removedProducts, "removed products should not be nil")
+        XCTAssertNotNil(list.sections, "current products should not be nil")
         XCTAssert(list.name == "Test list")
         XCTAssert(list.index == 0)
-        XCTAssert(list.currentProducts!.count == 0)
-        XCTAssert(list.removedProducts!.count == 0)
+        XCTAssert(list.sections!.count == 1)
+        XCTAssert((list.sections!.firstObject as! Section).name == "Items")
         
     }
     
@@ -65,18 +64,14 @@ class ListTableManagerTests : XCTestCase {
     func testEditList() {
         
         let list = listManager.addList(name: "Test list")
-        let id = list.id
         let index = list.index
-        let currentProducts = list.currentProducts
-        let removedProducts = list.removedProducts
+        let sections = list.sections
         
         listManager.updateList(list: list, name: "Test")
         
         XCTAssert(list.name == "Test")
-        XCTAssert(list.id == id)
         XCTAssert(list.index == index)
-        XCTAssert(list.currentProducts == currentProducts)
-        XCTAssert(list.removedProducts == removedProducts)
+        XCTAssert(list.sections == sections)
         
     }
     


### PR DESCRIPTION
Lists can now be grouped into sections. Each section has buttons to add, scan and undo removed products, and in edit mode you can change section headers and delete sections. Products can still be moved between sections.

You can add sections at the bottom of the screen, and clearing the list clears all products and all sections.

Closes #3.